### PR TITLE
CMake and MSVC build support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "windows/dirent"]
+	path = windows/dirent
+	url = https://github.com/tronkko/dirent.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+project(fsbld)
+
+include(CheckIncludeFile)
+
+CHECK_INCLUDE_FILE(dirent.h HAS_DIRENT_H)
+
+if (WIN32)
+	set(SOURCES windows/fsbld-win.c)
+	include_directories(windows)
+	if (NOT HAS_DIRENT_H)
+		include_directories(windows/dirent/include)
+	endif()
+else()
+	set(SOURCES osx/fsbld.c)
+	include_directories(osx)
+endif()
+
+add_executable(${PROJECT_NAME} ${SOURCES})


### PR DESCRIPTION
This adds cmake and check for dirent.h. Provides a dirent.h implementation via submodule for compilers that don't have it on windows such as Microsoft Visual Studio compilers. Tested with VS2019 x64